### PR TITLE
add config update for cmd_line field

### DIFF
--- a/src/cmd/builtin.py
+++ b/src/cmd/builtin.py
@@ -361,7 +361,7 @@ class BuiltinCommands(BaseCmd):
                 if cmd.message is not None:
                     s = (name, cmd.message)
                     commands.append(s)
-                elif hasattr(cmd, "cmd_line") and cmd.cmd_line is not None:
+                elif cmd.cmd_line is not None:
                     s = (name, "calls external command '{}'".format(cmd.cmd_line))
                     commands.append(s)
             commands.sort()
@@ -396,7 +396,7 @@ class BuiltinCommands(BaseCmd):
                 result += command.get_actor().__doc__
             elif command.message is not None:
                 result += command.message
-            elif hasattr(command, "cmd_line") and command.cmd_line is not None:
+            elif command.cmd_line is not None:
                 result += "calls external command '{}'".format(command.cmd_line)
             else:
                 result += "<error>"

--- a/src/const.py
+++ b/src/const.py
@@ -2,7 +2,7 @@ import re
 
 from enum import Enum, unique
 
-CONFIG_VERSION = '0.0.4'
+CONFIG_VERSION = '0.0.5'
 MARKOV_CONFIG_VERSION = '0.0.1'
 SECRET_CONFIG_VERSION = '0.0.1'
 

--- a/src/patch/updater.py
+++ b/src/patch/updater.py
@@ -41,6 +41,13 @@ class Updater:
             self.modified = True
             log.info("Successfully upgraded your config.yaml to version 0.0.4")
         if config.version == "0.0.4":
+            for key in config.commands.data.keys():
+                if not hasattr(config.commands.data[key], "cmd_line"):
+                    config.commands.data[key].cmd_line = None
+            config.version = "0.0.5"
+            self.modified = True
+            log.info("Successfully upgraded your config.yaml to version 0.0.5")
+        elif config.version == "0.0.5":
             log.info("Version is up to date!")
         else:
             log.error("Unknown version {}!".format(config.version))


### PR DESCRIPTION
I suggest to add this to updater.py. It adds cmd_line field to every command in config.yaml, if it wasn't added before.