### PR TITLE
Replace 'googletrans' dependency with 'pygoogletranslation'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ GitPython==3.1.30
 PyYAML==6.0
 yt-dlp==2022.11.11
 python-telegram-bot==13.15
-googletrans==4.0.0rc1
+git+https://github.com/Saravananslb/py-googletranslation@main
 nest-asyncio==1.5.6
 python-magic==0.4.27

--- a/src/cmd/services.py
+++ b/src/cmd/services.py
@@ -5,8 +5,8 @@ import sys
 from typing import List, Optional
 from urllib.parse import urlparse
 
-from googletrans import Translator
 from httpcore import SyncHTTPProxy
+from pygoogletranslation import Translator
 
 from src import const
 from src.api.command import BaseCmd, Command, Implementation

--- a/src/info.py
+++ b/src/info.py
@@ -88,7 +88,7 @@ class BotInfo:
         res["PyYAML"] = importlib.import_module("yaml").__version__
         res["yt_dlp"] = importlib.import_module("yt_dlp.update").__version__
         res["python-telegram-bot"] = importlib.import_module("telegram").__version__
-        res["googletrans"] = importlib.import_module("googletrans").__version__
+        res["pygoogletranslation"] = importlib.import_module("pygoogletranslation").__version__
         res["nest-asyncio"] = self._get_version_from_requirements_txt("nest-asyncio")
         return res
 


### PR DESCRIPTION
Replace `googletrans==4.0.0rc1` with `pygoogletranslation==2.0.6` because the first one is not maintained anymore and causes dependencies problems