### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install linter
       run: |
         python -m pip install --upgrade pip
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install linter
       run: |
         python -m pip install --upgrade pip
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         cache: pip
         cache-dependency-path: |
           requirements.txt
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         cache: pip
         cache-dependency-path: |
           requirements.txt
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         cache: pip
         cache-dependency-path: |
           requirements.txt

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - 'pypy3.8'
         - 'pypy3.9'
+        - 'pypy3.10'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
+        - '3.12'
         os-image:
         - ubuntu-latest
         - macos-latest
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
         cache: pip
         cache-dependency-path: |
           requirements.txt

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Discord bot written in Python*
   ```sh
   $ brew install libmagic
   ```
-- [Python](https://www.python.org/) 3.8-3.11
+- [Python](https://www.python.org/) 3.9-3.12
 
 ##### Optional
 - [ffmpeg](https://www.ffmpeg.org/) - for built-in DiscordVideoQueue plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8 <3.12"
-numpy = "1.24.3"
-py-cord = {version = "2.4.1", extras = ["voice"]}
+python = ">=3.9 <3.13"
+numpy = "1.26.4"
+py-cord = {git = "https://github.com/Pycord-Development/pycord", rev = "8a7ea47", extras = ["voice"]}
 requests = "2.31.0"
 psutil = "5.9.7"
 python-dateutil = "2.8.2"

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,1 +1,1 @@
-numba==0.58.1 ; platform_python_implementation=="CPython"
+numba==0.59.0 ; platform_python_implementation=="CPython"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy==1.24.3
-py-cord[voice]==2.4.1
+numpy==1.26.4
+git+https://github.com/Pycord-Development/pycord@8a7ea47#egg=py-cord[voice]
 requests==2.31.0
 psutil==5.9.8
 python_dateutil==2.8.2

--- a/src/backend/discord/cmd/builtin.py
+++ b/src/backend/discord/cmd/builtin.py
@@ -149,8 +149,9 @@ class BuiltinCommands(BaseCmd):
             bc.discord.commands.data[command_name].message = ' '.join(command[2:])
             return null(
                 await Msg.response(
-                    message, f"Command '{command_name}' -> "
-                             f"'{bc.discord.commands.data[command_name].message}' successfully updated", silent))
+                    message,
+                    f"Command '{command_name}' -> "
+                    f"'{bc.discord.commands.data[command_name].message}' successfully updated", silent))
         await Msg.response(message, f"Command '{command_name}' does not exist", silent)
 
     @staticmethod

--- a/src/cmd/markov.py
+++ b/src/cmd/markov.py
@@ -147,7 +147,7 @@ class MarkovCommands(BaseCmd):
             return
         if not 0 <= index < amount:
             return await Command.send_message(
-                execution_ctx, f"Wrong index in list '{cmd_line[2]}' (should be in range [0..{amount-1}])")
+                execution_ctx, f"Wrong index in list '{cmd_line[2]}' (should be in range [0..{amount - 1}])")
         result = found[index]
         await Command.send_message(execution_ctx, result)
         return result

--- a/src/cmd/math.py
+++ b/src/cmd/math.py
@@ -119,8 +119,9 @@ class MathCommands(BaseCmd):
         if len(expressions) != 2:
             return null(
                 await Command.send_message(
-                    execution_ctx, f"There should be only 2 branches ('then' and 'else') "
-                                   f"separated by ';' in '{cmd_line[0]}' command"))
+                    execution_ctx,
+                    f"There should be only 2 branches ('then' and 'else') "
+                    f"separated by ';' in '{cmd_line[0]}' command"))
         result = expressions[0] if condition != 0 else expressions[1]
         await Command.send_message(execution_ctx, result)
         return result

--- a/walbot.py
+++ b/walbot.py
@@ -11,8 +11,8 @@ import sys
 
 def main():
     """WalBot launcher entrypoint"""
-    if not ((3, 8) <= sys.version_info[:3] < (3, 12)):
-        print("Python {}.{}.{} is not supported. You need Python 3.8 - 3.11".format(
+    if not ((3, 9) <= sys.version_info[:3] < (3, 13)):
+        print("Python {}.{}.{} is not supported. You need Python 3.9 - 3.12".format(
             sys.version_info.major, sys.version_info.minor, sys.version_info.micro))
         sys.exit(1)
     walbot_dir = os.path.normpath(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
Supported versions for Python: CPython 3.9 - 3.12, pypy 3.9 - 3.10

- Drop support for Python 3.8 (latest numpy dropped support for 3.8)
- Update numpy version: 1.24.3 -> 1.26.4
- Update numba version: 0.58.1 -> 0.59.0