### PR TITLE
Switch to 'req @ url' syntax for py-cord dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.26.4
-git+https://github.com/Pycord-Development/pycord@8a7ea47#egg=py-cord[voice]
+py-cord[voice] @ git+https://github.com/Pycord-Development/pycord@8a7ea47
 requests==2.31.0
 psutil==5.9.8
 python_dateutil==2.8.2


### PR DESCRIPTION
Fixes the following warning:

DEPRECATION: git+https://github.com/Pycord-Development/pycord@8a7ea47#egg=py-cord[voice] contains an egg fragment with a non-PEP 508 name pip 25.0 will enforce this behaviour change. A possible replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be found at https://github.com/pypa/pip/issues/11617