### PR TITLE
Bump python-telegram-bot version (20.3 -> 20.7), align deps versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,14 +11,14 @@ python = ">=3.9 <3.13"
 numpy = "1.26.4"
 py-cord = {git = "https://github.com/Pycord-Development/pycord", rev = "8a7ea47", extras = ["voice"]}
 requests = "2.31.0"
-psutil = "5.9.7"
+psutil = "5.9.8"
 python-dateutil = "2.9.0.post0"
 gitpython = "3.1.42"
 pyyaml = "6.0.1"
 yt-dlp = "2023.12.30"
-python-telegram-bot = "20.3"
+python-telegram-bot = "20.7"
 aiogoogletrans = {git = "https://github.com/aobolensk/aiogoogletrans", rev = "master"}
-nest-asyncio = "1.5.9"
+nest-asyncio = "1.6.0"
 python-magic = "0.4.27"
 
 [tool.poetry.group.test]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@ numpy==1.26.4
 py-cord[voice] @ git+https://github.com/Pycord-Development/pycord@8a7ea47
 requests==2.31.0
 psutil==5.9.8
-python_dateutil==2.8.2
+python_dateutil==2.9.0.post0
 GitPython==3.1.42
 PyYAML==6.0.1
 yt-dlp==2023.12.30
-python-telegram-bot==20.3
+python-telegram-bot==20.7
 git+https://github.com/aobolensk/aiogoogletrans@master
 nest-asyncio==1.6.0
 python-magic==0.4.27


### PR DESCRIPTION
- Bump python-telegram-bot version from 20.3 to 20.7, depend on newly bumped version of aiogoogletrans
- Align requirements.txt and pyproject.toml dependencies versions