### PR TITLE
Bump numba from 0.60.0 to 0.61.0

### DIFF
--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,2 +1,2 @@
-numba==0.60.0 ; platform_python_implementation=="CPython"
+numba==0.61.0 ; platform_python_implementation=="CPython" and python_version>="3.10"
 openai==1.60.0


### PR DESCRIPTION
Do not install numba on Python 3.9, because support of Python 3.9 is dropped by numba