### PR TITLE
Fix embed suppression argument

### DIFF
--- a/src/cmd/builtin.py
+++ b/src/cmd/builtin.py
@@ -221,7 +221,7 @@ class BuiltinCommands(BaseCmd):
             for cmd_name, cmd_desc in commands:
                 result += f"{cmd_name}: {cmd_desc}\n"
 
-        await Command.send_message(execution_ctx, result, suppress_emdebs=True)
+        await Command.send_message(execution_ctx, result, suppress_embeds=True)
 
     async def _about(self, cmd_line: List[str], execution_ctx: ExecutionContext) -> None:
         """Get information about the bot


### PR DESCRIPTION
## Summary
- correct a typo to suppress Discord embeds in help command

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6852513af388832fb06f0c5862d65b14