### PR TITLE
[CI] Add concurrency control to workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/master' &&
+        github.event_name != 'merge_group' &&
+        !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
+
 jobs:
   linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/master' &&
+        github.event_name != 'merge_group' &&
+        !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
+
 jobs:
   codecov:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/master' &&
+        github.event_name != 'merge_group' &&
+        !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
+
 jobs:
   tests:
     strategy:

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -11,6 +11,13 @@ on:
       - "**/*.yaml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: >-
+    ${{ github.ref != 'refs/heads/master' &&
+        github.event_name != 'merge_group' &&
+        !startsWith(github.ref, 'refs/heads/gh-readonly-queue') }}
+
 jobs:
   yaml-lint:
     name: Validate YAML files


### PR DESCRIPTION
Prevent duplicate workflow runs by adding concurrency to jobs triggered on push/pull requests