### PR TITLE
Remove redundant empty __init__ methods

### DIFF
--- a/src/cmd/auth.py
+++ b/src/cmd/auth.py
@@ -14,9 +14,6 @@ from src.log import log
 
 
 class AuthCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["authorize"] = Command(
             "auth", "authorize", const.Permission.USER, Implementation.FUNCTION,

--- a/src/cmd/builtin.py
+++ b/src/cmd/builtin.py
@@ -57,9 +57,6 @@ class _BuiltinInternals:
 
 
 class BuiltinCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["ping"] = Command(
             "builtin", "ping", const.Permission.USER, Implementation.MESSAGE,

--- a/src/cmd/custom_cmds.py
+++ b/src/cmd/custom_cmds.py
@@ -9,9 +9,6 @@ from src.config import bc
 
 
 class CustomCmdsCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["addextcmd"] = Command(
             "custom-commands", "addextcmd", const.Permission.ADMIN, Implementation.FUNCTION,

--- a/src/cmd/debug.py
+++ b/src/cmd/debug.py
@@ -29,9 +29,6 @@ class _DebugCommand:
 
 
 class DebugCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["dbg"] = Command(
             "debug", "dbg", const.Permission.ADMIN, Implementation.FUNCTION,

--- a/src/cmd/image.py
+++ b/src/cmd/image.py
@@ -117,9 +117,6 @@ class _ImageInternals:
 
 
 class ImageCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["img"] = Command(
             "image", "img", const.Permission.USER, Implementation.FUNCTION,

--- a/src/cmd/interactive.py
+++ b/src/cmd/interactive.py
@@ -73,9 +73,6 @@ class _InteractiveCmdsInternals:
 
 
 class InteractiveCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["poll"] = Command(
             "interactive", "poll", const.Permission.USER, Implementation.FUNCTION,

--- a/src/cmd/markov.py
+++ b/src/cmd/markov.py
@@ -11,9 +11,6 @@ from src.utils import Util, null
 
 
 class MarkovCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["markov"] = Command(
             "markov", "markov", const.Permission.USER, Implementation.FUNCTION,

--- a/src/cmd/math.py
+++ b/src/cmd/math.py
@@ -61,9 +61,6 @@ class MathExprEvaluator:
 
 
 class MathCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["calc"] = Command(
             "math", "calc", const.Permission.USER, Implementation.FUNCTION,

--- a/src/cmd/quote.py
+++ b/src/cmd/quote.py
@@ -14,9 +14,6 @@ from src.utils import Util
 
 
 class RandomCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self):
         bc.executor.commands["quote"] = Command(
             "quote", "quote", const.Permission.USER, Implementation.FUNCTION,

--- a/src/cmd/random.py
+++ b/src/cmd/random.py
@@ -9,9 +9,6 @@ from src.utils import Util
 
 
 class RandomCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["random"] = Command(
             "random", "random", const.Permission.USER, Implementation.FUNCTION,

--- a/src/cmd/reaction.py
+++ b/src/cmd/reaction.py
@@ -13,9 +13,6 @@ from src.utils import Util
 
 
 class ReactionCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["addreaction"] = Command(
             "reaction", "addreaction", const.Permission.MOD, Implementation.FUNCTION,

--- a/src/cmd/reminder.py
+++ b/src/cmd/reminder.py
@@ -210,9 +210,6 @@ class _ReminderInternals:
 
 
 class ReminderCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["reminder"] = Command(
             "reminder", "reminder", const.Permission.USER, Implementation.FUNCTION,

--- a/src/cmd/string.py
+++ b/src/cmd/string.py
@@ -9,9 +9,6 @@ from src.utils import Util
 
 
 class StringCommands(BaseCmd):
-    def __init__(self) -> None:
-        pass
-
     def bind(self) -> None:
         bc.executor.commands["emojify"] = Command(
             "string", "emojify", const.Permission.USER, Implementation.FUNCTION,


### PR DESCRIPTION
## Summary
- remove `__init__` methods that only contained `pass` from command classes under `src/cmd/`
- clean up blank lines left after removing those methods