### PR TITLE
Fix Shell command quoting

### DIFF
--- a/src/shell.py
+++ b/src/shell.py
@@ -32,8 +32,25 @@ class Shell:
             env: Optional[Dict[str, str]] = None, shell: bool = False) -> ShellCommandResult:
         """Run shell command synchronously and return its result."""
         log.debug("Executing shell command: " + cmd_line)
-        cmd = shlex.split(cmd_line)
-        proc = subprocess.Popen(cmd, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=shell)
+        if shell:
+            proc = subprocess.Popen(
+                cmd_line,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=True,
+            )
+        else:
+            cmd = shlex.split(cmd_line)
+            proc = subprocess.Popen(
+                cmd,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                shell=False,
+            )
         stdout, stderr = proc.communicate()
         return ShellCommandResult(proc.returncode, stdout.decode('utf-8'), stderr.decode('utf-8'))
 
@@ -45,15 +62,26 @@ class Shell:
             timeout: int = 10) -> ShellCommandResult:
         """Run shell command asynchronously with optional timeout."""
         log.debug("Executing shell command: " + cmd_line)
-        cmd = shlex.split(cmd_line)
         if shell:
             proc = await asyncio.create_subprocess_shell(
-                cmd_line, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                cmd_line,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
         else:
+            cmd = shlex.split(cmd_line)
             program = cmd[0]
             program_args = cmd[1:]
             proc = await asyncio.create_subprocess_exec(
-                program, *program_args, cwd=cwd, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                program,
+                *program_args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
         try:
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
             ret_code = proc.returncode

--- a/tests/shell_tests.py
+++ b/tests/shell_tests.py
@@ -1,0 +1,27 @@
+import asyncio
+
+from src.shell import Shell
+
+
+def test_run_shell_false_star():
+    result = Shell.run('echo "*"')
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '*'
+
+
+def test_run_shell_true_quotes_preserved():
+    result = Shell.run('echo "*"', shell=True)
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '*'
+
+
+def test_run_async_shell_false_star():
+    result = asyncio.run(Shell.run_async('echo "*"'))
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '*'
+
+
+def test_run_async_shell_true_quotes_preserved():
+    result = asyncio.run(Shell.run_async('echo "*"', shell=True))
+    assert result.exit_code == 0
+    assert result.stdout.strip() == '*'


### PR DESCRIPTION
## Summary
- retain the original command string for shell-mode execution
- only shlex.split commands when `shell=False`
- add tests covering both sync and async shell execution paths

## Testing
- `pytest tests/shell_tests.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6855019222b8832f98c273fa33279cd7