### PR TITLE
Fix MarkovNode.get_next return type

### DIFF
--- a/src/markov.py
+++ b/src/markov.py
@@ -32,7 +32,7 @@ class MarkovNode:
             self.total_next -= self.next[word]
             del self.next[word]
 
-    def get_next(self, model: 'Markov', word: str) -> MarkovNode:
+    def get_next(self, model: 'Markov', word: str) -> 'MarkovNode':
         if not FF.is_enabled("WALBOT_FEATURE_MARKOV_MONGO"):
             if word is not None:
                 return model.model[word]

--- a/src/markov.py
+++ b/src/markov.py
@@ -32,7 +32,7 @@ class MarkovNode:
             self.total_next -= self.next[word]
             del self.next[word]
 
-    def get_next(self, model: 'Markov', word: str) -> str:
+    def get_next(self, model: 'Markov', word: str) -> MarkovNode:
         if not FF.is_enabled("WALBOT_FEATURE_MARKOV_MONGO"):
             if word is not None:
                 return model.model[word]


### PR DESCRIPTION
Correct return type annotation for `MarkovNode.get_next`