### PR TITLE
Make HTTP utilities asynchronous

### DIFF
--- a/src/backend/telegram/context.py
+++ b/src/backend/telegram/context.py
@@ -46,7 +46,7 @@ class TelegramExecutionContext(ExecutionContext):
         await self.send_message(message, *args, **kwargs, reply_on_msg=True)
 
     async def send_direct_message(self, user_id: int, message: str, *args, **kwargs) -> None:
-        send_message(user_id, message)
+        await send_message(user_id, message)
 
     def _unescape_ping1(self, message: str) -> str:
         idx = 0

--- a/src/backend/telegram/util.py
+++ b/src/backend/telegram/util.py
@@ -60,7 +60,7 @@ async def reply(update: Update, text: str, disable_web_page_preview: bool = Fals
     log.info(f"({title}) {reply_message.from_user.username}: {reply_message.text}")
 
 
-def send_message(chat_id: int, text: str) -> None:
+async def send_message(chat_id: int, text: str) -> None:
     log.info(f"({chat_id}) /sendMessage: " + text)
     text = quote_plus(escape_markdown_text(text))
     url = (
@@ -68,6 +68,6 @@ def send_message(chat_id: int, text: str) -> None:
         f"?chat_id={chat_id}&text={text}&parse_mode=MarkdownV2"
     )
     rq = Util.request(url)
-    r = rq.get()
+    r = await rq.get()
     if r.status_code != 200:
         log.error(f"Error sending message to {chat_id}: {r.status_code} {r.json()}")

--- a/src/cmd/builtin.py
+++ b/src/cmd/builtin.py
@@ -292,7 +292,7 @@ class BuiltinCommands(BaseCmd):
             return None
         try:
             r = Util.request(args.url, use_proxy=args.use_proxy)
-            result = r.get_text()
+            result = await r.get_text()
             await Command.send_message(execution_ctx, result)
             return result
         except Exception as e:

--- a/src/cmd/image.py
+++ b/src/cmd/image.py
@@ -41,7 +41,7 @@ class _ImageInternals:
                     # Unicode emoji
                     if const.UNICODE_EMOJI_REGEX.match(cmd_line[i]):
                         rq = Util.request("https://unicode.org/emoji/charts/full-emoji-list.html")
-                        emojis_page = rq.get_text()
+                        emojis_page = await rq.get_text()
                         emoji_match = r"<img alt='{}' class='imga' src='data:image/png;base64,([^']+)'>"
                         emoji_match = re.findall(emoji_match.format(cmd_line[i]), emojis_page)
                         if emoji_match:

--- a/src/cmd/services.py
+++ b/src/cmd/services.py
@@ -45,7 +45,8 @@ class TimerCommands(BaseCmd):
                 stderr=subprocess.PIPE,
                 shell=True)
             try:
-                output, err = p.communicate(input=r.get_text().encode("utf-8"), timeout=45)
+                script_text = await r.get_text()
+                output, err = p.communicate(input=script_text.encode("utf-8"), timeout=45)
             except subprocess.TimeoutExpired:
                 p.kill()
                 result += "Speedtest: operation timed out\n"
@@ -96,7 +97,7 @@ class TimerCommands(BaseCmd):
         city = ' '.join(cmd_line[1:])
         try:
             r = Util.request(f"https://wttr.in/{city}?format=4")
-            result = r.get_text()
+            result = await r.get_text()
             await Command.send_message(execution_ctx, result)
             return result
         except HTTPRequestException as e:
@@ -120,7 +121,7 @@ class TimerCommands(BaseCmd):
         city = ' '.join(cmd_line[1:])
         try:
             r = Util.request(f"https://wttr.in/{city}.png?m")
-            file_name = r.get_file(extension=".png")
+            file_name = await r.get_file(extension=".png")
             await Command.send_message(execution_ctx, None, files=[file_name])
             os.unlink(file_name)
         except HTTPRequestException as e:

--- a/src/reminder.py
+++ b/src/reminder.py
@@ -49,7 +49,7 @@ class ReminderProcessing:
                     elif backend == const.BotBackend.TELEGRAM:
                         result = f"{prereminder} minutes left until reminder\n"
                         result += rem.message + "\n" + rem.notes + "\n"
-                        send_message(rem.channel_id, result)
+                        await send_message(rem.channel_id, result)
                     else:
                         log.error(f"ReminderProcessing: backend '{backend}' is not supported")
                     rem.used_prereminders_list[i] = True
@@ -72,9 +72,9 @@ class ReminderProcessing:
                     clock_emoji = get_clock_emoji(Time().now().strftime("%H:%M"))
                     result += f"{clock_emoji} You asked to remind at {now}\n"
                     result += rem.message + "\n" + rem.notes + "\n"
-                    send_message(rem.channel_id, result)
+                    await send_message(rem.channel_id, result)
                     for user_id in rem.telegram_whisper_users:
-                        send_message(user_id, result)
+                        await send_message(user_id, result)
                 else:
                     log.error(f"ReminderProcessing: backend '{backend}' is not supported")
                 if rem.email_users:

--- a/src/utils.py
+++ b/src/utils.py
@@ -148,22 +148,28 @@ class Util:
             else:
                 self.proxies = None
 
-        def get(self) -> requests.Response:
+        async def get(self) -> requests.Response:
             """Get request"""
-            return requests.get(self.url, timeout=self.timeout, headers=self.headers, proxies=self.proxies)
+            return await asyncio.to_thread(
+                requests.get,
+                self.url,
+                timeout=self.timeout,
+                headers=self.headers,
+                proxies=self.proxies,
+            )
 
-        def get_text(self) -> str:
+        async def get_text(self) -> str:
             """Get request text"""
-            response = self.get()
+            response = await self.get()
             if response.status_code == 200:
                 return response.text
             else:
                 log.error(f"Request failed with status code {response.status_code}")
                 raise HTTPRequestException(response)
 
-        def get_file(self, extension='') -> str:
+        async def get_file(self, extension='') -> str:
             """Get file request. Returns path to temporary file"""
-            response = requests.get(self.url, timeout=self.timeout, headers=self.headers, proxies=self.proxies)
+            response = await self.get()
             if response.status_code == 200:
                 with tempfile.NamedTemporaryFile(dir=Util.tmp_dir(), suffix=extension, delete=False) as tmp_file:
                     tmp_file.write(response.content)

--- a/tests/util_tests.py
+++ b/tests/util_tests.py
@@ -78,9 +78,24 @@ def test_request_get_file_creates_missing_dir(monkeypatch, tmp_path):
     if tmp_dir.exists():
         shutil.rmtree(tmp_dir)
 
-    file_path = Util.request("http://example.com").get_file(".bin")
+    file_path = asyncio.run(Util.request("http://example.com").get_file(".bin"))
 
     assert tmp_dir.exists()
     assert os.path.isfile(file_path)
     with open(file_path, "rb") as f:
         assert f.read() == b"file data"
+
+
+def test_request_get_text(monkeypatch):
+    class DummyResponse:
+        status_code = 200
+        text = "hello"
+
+    def dummy_get(*args, **kwargs):
+        return DummyResponse()
+
+    monkeypatch.setattr(requests, "get", dummy_get)
+
+    result = asyncio.run(Util.request("http://example.com").get_text())
+
+    assert result == "hello"


### PR DESCRIPTION
- make `Util.request` methods async via `asyncio.to_thread`
- update bot commands and utilities to await new async APIs
- update Telegram utilities for async `send_message`
- adapt reminder logic for async API
- extend util tests for async `get_text` and update `get_file`