### PR TITLE
Add type hints and run mypy

### DIFF
--- a/src/algorithms.py
+++ b/src/algorithms.py
@@ -1,12 +1,14 @@
 import importlib
-from typing import Any
+from typing import Callable, TypeVar
 
 import numpy as np
 
 from src.log import log
 
+F = TypeVar("F", bound=Callable[..., object])
 
-def optional_numba_jit(func) -> Any:
+
+def optional_numba_jit(func: F) -> F:
     try:
         numba = importlib.import_module("numba")
     except Exception as e:
@@ -19,7 +21,7 @@ def optional_numba_jit(func) -> Any:
 
 
 @optional_numba_jit
-def levenshtein_distance(a: str, b: str):
+def levenshtein_distance(a: str, b: str) -> int:
     """
     Calculates Levenshtein distance between two strings using dynamic programming.
     Complexity: O(len(a) * len(b))

--- a/src/api/bot_instance.py
+++ b/src/api/bot_instance.py
@@ -10,7 +10,7 @@ class BotInstance:
         pass
 
     @abstractmethod
-    def stop(self, args) -> None:
+    def stop(self, args, main_bot: bool = True) -> None:
         pass
 
     @abstractmethod

--- a/src/backend/discord/config.py
+++ b/src/backend/discord/config.py
@@ -3,5 +3,5 @@ from typing import Any, Dict
 
 class DiscordConfig:
     def __init__(self) -> None:
-        self.guilds: Dict[str, Any] = dict()
-        self.users: Dict[str, Any] = dict()
+        self.guilds: Dict[int, Any] = dict()
+        self.users: Dict[int, Any] = dict()

--- a/src/backend/discord/instance.py
+++ b/src/backend/discord/instance.py
@@ -314,7 +314,7 @@ class DiscordBotInstance(BotInstance):
         except discord.PrivilegedIntentsRequired:
             log.error("Privileged Gateway Intents are not enabled! Shutting down the bot...")
 
-    def stop(self, args, main_bot=True):
+    def stop(self, args, main_bot: bool = True) -> None:
         pass
 
     def has_credentials(self):

--- a/src/backend/repl/instance.py
+++ b/src/backend/repl/instance.py
@@ -62,7 +62,7 @@ class ReplBotInstance(BotInstance):
             except OSError as e:
                 log.warning(f"REPL: {e}")
 
-    def stop(self, args, main_bot=True) -> None:
+    def stop(self, args, main_bot: bool = True) -> None:
         if self.sock:
             self.sock.close()
 

--- a/src/backend/telegram/config.py
+++ b/src/backend/telegram/config.py
@@ -6,4 +6,4 @@ class TelegramConfig:
     def __init__(self) -> None:
         self.channel_whitelist: Set[str] = set()
         self.passphrase = uuid.uuid4().hex
-        self.users: Dict[str, Any] = dict()
+        self.users: Dict[int, Any] = dict()

--- a/src/backend/telegram/instance.py
+++ b/src/backend/telegram/instance.py
@@ -103,7 +103,7 @@ class TelegramBotInstance(BotInstance):
                 except Exception as e:
                     log.error(f"Error in processing reminders: {e}")
 
-    def stop(self, args, main_bot=True) -> None:
+    def stop(self, args, main_bot: bool = True) -> None:
         self._is_stopping = True
 
     def has_credentials(self):

--- a/src/info.py
+++ b/src/info.py
@@ -103,7 +103,7 @@ class BotInfo:
         minutes, seconds = divmod(remainder, 60)
         return f"{days}:{hours:02}:{minutes:02}:{seconds:02}"
 
-    def get_full_info(self, verbosity) -> str:
+    def get_full_info(self, verbosity: int) -> str:
         result = f"{const.INSTANCE_NAME} (WalBot instance)\n"
         result += "Backends:\n"
         if bc.be.is_running(const.BotBackend.DISCORD):

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -139,7 +139,7 @@ class Launcher:
         log.info('Stopped the bot!')
         sys.exit(const.ExitStatus.NO_ERROR)
 
-    def _stop_signal_handler_mini(self, sig, frame):
+    def _stop_signal_handler_mini(self, sig: int, frame: FrameType) -> None:
         for backend in self.backends:
             backend.stop(self.args, main_bot=False)
             log.debug2("Stopped backend: " + backend.name)

--- a/src/log.py
+++ b/src/log.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 import logging.config
 import os
-from typing import Any
+from typing import Callable
 
 from src import const
 
@@ -67,18 +67,18 @@ class Log:
         self.debug3 = functools.partial(self.log.log, const.LogLevel.DEBUG3)
         self.info("Logging system is set up")
 
-    def trace_function(self, func) -> Any:
+    def trace_function(self, func: Callable[..., object]) -> Callable[..., object]:
         """Tracing enter and exit events for functions. It should be used as a decorator"""
         if inspect.iscoroutinefunction(func):
             @functools.wraps(func)
-            async def wrapped(*args):
+            async def wrapped(*args: object, **kwargs: object) -> object:
                 self.debug(f"Function '{func.__name__}' (ENTER)")
-                ret = await func(*args)
+                ret = await func(*args, **kwargs)
                 self.debug(f"Function '{func.__name__}' (EXIT)")
                 return ret
             return wrapped
         else:
-            def inner(*args, **kwargs):
+            def inner(*args: object, **kwargs: object) -> object:
                 self.debug(f"Function '{func.__name__}' (ENTER)")
                 ret = func(*args, **kwargs)
                 self.debug(f"Function '{func.__name__}' (EXIT)")

--- a/src/test.py
+++ b/src/test.py
@@ -2,11 +2,12 @@ import os
 import shlex
 import subprocess
 import sys
+from argparse import Namespace
 
 from src.log import log
 
 
-def start_testing(args):
+def start_testing(args: Namespace) -> int:
     if args.verbose2:
         args.verbose = True
     pytest_args = []


### PR DESCRIPTION
## Summary
- add annotations for helper modules
- refine logging decorators and mail exception handler
- type GuildSettings and config functions
- install stubs for mypy
- fix mypy errors and refine types
- set `from __future__ import annotations`

## Testing
- `python -m mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a409def14832f899e9cf352a4b358