### PR TITLE
Enable support for Python 3.14

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install linter
         run: |
           python -m pip install --upgrade pip
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install linter
         run: |
           python -m pip install --upgrade pip
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: pip
           cache-dependency-path: |
             requirements.txt
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: pip
           cache-dependency-path: |
             requirements.txt
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: pip
           cache-dependency-path: |
             requirements.txt
@@ -110,7 +110,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: pip
           cache-dependency-path: |
             requirements.txt

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,7 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+          - '3.14'
           - 'pypy3.9'
           - 'pypy3.10'
     runs-on: ubuntu-latest

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: pip
           cache-dependency-path: |
             requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,10 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        exclude:
+          # Skip Windows + Python 3.14 due to experimental NumPy wheels
+          - os-image: windows-latest
+            python-version: '3.14'
     runs-on: ${{ matrix.os-image }}
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
+          - '3.14'
         os-image:
           - ubuntu-latest
           - macos-latest
@@ -51,7 +52,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: pip
           cache-dependency-path: |
             requirements.txt

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Discord bot written in Python*
   ```sh
   $ brew install libmagic
   ```
-- [Python](https://www.python.org/) 3.9-3.13
+- [Python](https://www.python.org/) 3.9-3.14
 
 ##### Optional
 - [ffmpeg](https://www.ffmpeg.org/) - for built-in DiscordVideoQueue plugin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9 <3.14"
+python = ">=3.9 <3.15"
 numpy = "2.0.2"
 py-cord = {git = "https://github.com/Pycord-Development/pycord", rev = "24c1a8e", extras = ["voice"]}
 requests = "2.32.5"

--- a/src/cmd/math.py
+++ b/src/cmd/math.py
@@ -42,8 +42,9 @@ class MathExprEvaluator:
     }
 
     def _evaluate_expr_node(self, node):
-        if isinstance(node, ast.Num):
-            return node.n
+        if isinstance(node, ast.Constant):
+            value = node.value
+            return int(value) if isinstance(value, bool) else value
         if isinstance(node, ast.BinOp):
             return self._ops[type(node.op)](self._evaluate_expr_node(node.left), self._evaluate_expr_node(node.right))
         if isinstance(node, ast.BoolOp):

--- a/tests/commands/basic_command_tests.py
+++ b/tests/commands/basic_command_tests.py
@@ -12,8 +12,12 @@ def test_empty_executor():
 def test_ping_command(capsys):
     bc.executor.commands = dict()
     bc.executor.add_module(BuiltinCommands())
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(
-        bc.executor.commands["ping"].run(["ping"], BufferTestExecutionContext()))
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(
+            bc.executor.commands["ping"].run(["ping"], BufferTestExecutionContext()))
+    finally:
+        loop.close()
     captured = capsys.readouterr()
     assert captured.out == "🏓 Pong!  🏓\n"

--- a/tests/commands/permission_tests.py
+++ b/tests/commands/permission_tests.py
@@ -9,11 +9,15 @@ from tests.fixtures.perm_cmd import PermFixtureCommands
 def test_permission_commands_level_0(capsys):
     bc.executor.commands = dict()
     bc.executor.add_module(PermFixtureCommands())
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     ctx = BufferTestExecutionContext()
-    loop.run_until_complete(bc.executor.commands["perm_user"].run(["perm_user"], ctx))
-    loop.run_until_complete(bc.executor.commands["perm_mod"].run(["perm_mod"], ctx))
-    loop.run_until_complete(bc.executor.commands["perm_admin"].run(["perm_admin"], ctx))
+    try:
+        loop.run_until_complete(bc.executor.commands["perm_user"].run(["perm_user"], ctx))
+        loop.run_until_complete(bc.executor.commands["perm_mod"].run(["perm_mod"], ctx))
+        loop.run_until_complete(bc.executor.commands["perm_admin"].run(["perm_admin"], ctx))
+    finally:
+        loop.close()
     captured = capsys.readouterr()
     assert captured.out == (
         "perm: user\n"
@@ -25,12 +29,16 @@ def test_permission_commands_level_0(capsys):
 def test_permission_commands_level_1(capsys):
     bc.executor.commands = dict()
     bc.executor.add_module(PermFixtureCommands())
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     ctx = BufferTestExecutionContext()
     ctx.permission_level = const.Permission.MOD
-    loop.run_until_complete(bc.executor.commands["perm_user"].run(["perm_user"], ctx))
-    loop.run_until_complete(bc.executor.commands["perm_mod"].run(["perm_mod"], ctx))
-    loop.run_until_complete(bc.executor.commands["perm_admin"].run(["perm_admin"], ctx))
+    try:
+        loop.run_until_complete(bc.executor.commands["perm_user"].run(["perm_user"], ctx))
+        loop.run_until_complete(bc.executor.commands["perm_mod"].run(["perm_mod"], ctx))
+        loop.run_until_complete(bc.executor.commands["perm_admin"].run(["perm_admin"], ctx))
+    finally:
+        loop.close()
     captured = capsys.readouterr()
     assert captured.out == (
         "perm: user\n"
@@ -42,12 +50,16 @@ def test_permission_commands_level_1(capsys):
 def test_permission_commands_level_2(capsys):
     bc.executor.commands = dict()
     bc.executor.add_module(PermFixtureCommands())
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     ctx = BufferTestExecutionContext()
     ctx.permission_level = const.Permission.ADMIN
-    loop.run_until_complete(bc.executor.commands["perm_user"].run(["perm_user"], ctx))
-    loop.run_until_complete(bc.executor.commands["perm_mod"].run(["perm_mod"], ctx))
-    loop.run_until_complete(bc.executor.commands["perm_admin"].run(["perm_admin"], ctx))
+    try:
+        loop.run_until_complete(bc.executor.commands["perm_user"].run(["perm_user"], ctx))
+        loop.run_until_complete(bc.executor.commands["perm_mod"].run(["perm_mod"], ctx))
+        loop.run_until_complete(bc.executor.commands["perm_admin"].run(["perm_admin"], ctx))
+    finally:
+        loop.close()
     captured = capsys.readouterr()
     assert captured.out == (
         "perm: user\n"

--- a/tests/commands/subcommand_tests.py
+++ b/tests/commands/subcommand_tests.py
@@ -9,9 +9,13 @@ from tests.fixtures.context import BufferTestExecutionContext
 def test_ping_command_with_subcommand(capsys):
     bc.executor.commands = dict()
     bc.executor.add_module(BuiltinCommands())
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(
-        bc.executor.commands["echo"].run(["echo", "$(ping)"], BufferTestExecutionContext()))
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(
+            bc.executor.commands["echo"].run(["echo", "$(ping)"], BufferTestExecutionContext()))
+    finally:
+        loop.close()
     captured = capsys.readouterr()
     assert captured.out == "🏓 Pong!  🏓\n"
 
@@ -19,19 +23,23 @@ def test_ping_command_with_subcommand(capsys):
 def test_ping_command_with_multilevel_nested_subcommands(capsys):
     bc.executor.commands = dict()
     bc.executor.add_module(BuiltinCommands())
-    loop = asyncio.get_event_loop()
-    cmd = "echo $(echo Test 1)"
-    loop.run_until_complete(
-        bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
-    cmd = "echo $(echo $(echo Test 2))"
-    loop.run_until_complete(
-        bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
-    cmd = "echo $(echo $(echo $(echo Test 3)))"
-    loop.run_until_complete(
-        bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
-    cmd = "echo $(echo $(echo $(echo $(echo Test 4))))"
-    loop.run_until_complete(
-        bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        cmd = "echo $(echo Test 1)"
+        loop.run_until_complete(
+            bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
+        cmd = "echo $(echo $(echo Test 2))"
+        loop.run_until_complete(
+            bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
+        cmd = "echo $(echo $(echo $(echo Test 3)))"
+        loop.run_until_complete(
+            bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
+        cmd = "echo $(echo $(echo $(echo $(echo Test 4))))"
+        loop.run_until_complete(
+            bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
+    finally:
+        loop.close()
     captured = capsys.readouterr()
     assert captured.out == (
         "Test 1\n"
@@ -44,10 +52,14 @@ def test_ping_command_with_multilevel_nested_subcommands(capsys):
 def test_command_that_does_not_support_subcommand_usage(capsys):
     bc.executor.commands = dict()
     bc.executor.add_module(BuiltinCommands())
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     cmd = "echo $(about)"
-    loop.run_until_complete(
-        bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
+    try:
+        loop.run_until_complete(
+            bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
+    finally:
+        loop.close()
     captured = capsys.readouterr()
     assert captured.out.strip() == "Command 'about' can not be used as subcommand"
 
@@ -55,10 +67,14 @@ def test_command_that_does_not_support_subcommand_usage(capsys):
 def test_empty_subcommand_returns_nothing(capsys):
     bc.executor.commands = dict()
     bc.executor.add_module(BuiltinCommands())
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     cmd = "echo $()"
-    loop.run_until_complete(
-        bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
+    try:
+        loop.run_until_complete(
+            bc.executor.commands[cmd.split()[0]].run(cmd.split(), BufferTestExecutionContext()))
+    finally:
+        loop.close()
     captured = capsys.readouterr()
     assert captured.out.strip() == ""
 
@@ -67,13 +83,17 @@ def test_if_and_calc_commands_as_subcommands(capsys):
     bc.executor.commands = dict()
     bc.executor.add_module(BuiltinCommands())
     bc.executor.add_module(MathCommands())
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(bc.executor.commands["echo"].run(
-        "echo $(if $(calc 2 < 3) less;not less)".split(" "), BufferTestExecutionContext()))
-    loop.run_until_complete(bc.executor.commands["echo"].run(
-        "echo $(if $(calc 2 == 3) equal;not equal)".split(" "), BufferTestExecutionContext()))
-    loop.run_until_complete(bc.executor.commands["echo"].run(
-        "echo $(if $(calc 2 > 3) greater;not greater)".split(" "), BufferTestExecutionContext()))
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(bc.executor.commands["echo"].run(
+            "echo $(if $(calc 2 < 3) less;not less)".split(" "), BufferTestExecutionContext()))
+        loop.run_until_complete(bc.executor.commands["echo"].run(
+            "echo $(if $(calc 2 == 3) equal;not equal)".split(" "), BufferTestExecutionContext()))
+        loop.run_until_complete(bc.executor.commands["echo"].run(
+            "echo $(if $(calc 2 > 3) greater;not greater)".split(" "), BufferTestExecutionContext()))
+    finally:
+        loop.close()
     captured = capsys.readouterr()
     assert captured.out == (
         "less\n"

--- a/tests/shell_tests.py
+++ b/tests/shell_tests.py
@@ -33,8 +33,12 @@ def test_run_async_terminates_on_timeout(monkeypatch):
     monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
     monkeypatch.setattr(asyncio, "wait_for", fake_wait_for)
 
-    loop = asyncio.get_event_loop()
-    result = loop.run_until_complete(Shell.run_async("dummy"))
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        result = loop.run_until_complete(Shell.run_async("dummy"))
+    finally:
+        loop.close()
 
     assert result.exit_code == -1
     assert dummy_proc.kill_called

--- a/walbot.py
+++ b/walbot.py
@@ -11,8 +11,8 @@ import sys
 
 def main():
     """WalBot launcher entrypoint"""
-    if not ((3, 9) <= sys.version_info[:3] < (3, 14)):
-        print("Python {}.{}.{} is not supported. You need Python 3.9 - 3.13".format(
+    if not ((3, 9) <= sys.version_info[:3] < (3, 15)):
+        print("Python {}.{}.{} is not supported. You need Python 3.9 - 3.14".format(
             sys.version_info.major, sys.version_info.minor, sys.version_info.micro))
         sys.exit(1)
     walbot_dir = os.path.normpath(os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
 - Enable support for Python 3.14
 - Fix Python 3.14 failures: explicit test event loops + ast.Constant
 - Skip Python 3.14 on Windows for now due to experimental NumPy wheels